### PR TITLE
Initial implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+- 2.7
+- 3.4
+- 3.5
+before_install:
+- pip install nose coverage codecov
+- pip install -r requires/testing.txt
+install:
+- pip install -e .
+script: nosetests --with-coverage
+after_success:
+- codecov
+sudo: false

--- a/README.rst
+++ b/README.rst
@@ -33,3 +33,30 @@ That's it.  What you do not see is asynchronous client usage and logging
 that happens inside of the library.  There is some setup code in
 ``ClientMixin.initialize`` so make sure to call the super implementation
 if you implement ``initialize`` in your request handler.
+
+Running Tests
+-------------
+The test cases use the most excellent httpbin.org site to poke an HTTP API
+that responds to errors in a reliable manner. However this can cause failures
+if you happen to get rate limited by httpbin.org. If you want to be nice to
+the maintainers of httpbin.org, you can run a version in `docker`_ and point
+the tests at it instead.  The following snippet shows how to do this using
+`docker-machine`_ installed via `docker-toolbox`_:
+
+.. code-block:: bash
+
+   $ eval "$(docker-machine env default)"
+   $ machine_id=$(docker run -d -p 8000 citizenstig/httpbin)
+   $ export HTTPBIN_HOST=$(docker-machine ip default)
+   $ export HTTPBIN_PORT=$(docker port $machine_id 8000 | cut -d: -f2)
+   $ env/bin/nosetests
+   ........
+   ----------------------------------------------------------------------
+   Ran 8 tests in 0.255s
+
+   OK
+   $ docker stop $machine_id | xargs docker rm
+
+.. _docker: https://www.docker.com
+.. _docker-machine: https://www.docker.com/products/docker-machine
+.. _docker-toolbox: https://www.docker.com/products/docker-toolbox

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ not block the active IO loop.
        @gen.coroutine
        def get(self):
            response = yield self.make_http_request(
-               some_server_url, on_error=self.handle_api_error)
+               'GET', some_server_url, on_error=self.handle_api_error)
            if self._finished:
                yield gen.Return()
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,5 @@
+Reference Documentation
+=======================
+
+.. automodule:: sprockets.clients.http.mixins
+   :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,8 @@
 Reference Documentation
 =======================
 
+.. automodule:: sprockets.clients.http.client
+   :members:
+
 .. automodule:: sprockets.clients.http.mixins
    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,5 @@
 Reference Documentation
 =======================
 
-.. automodule:: sprockets.clients.http.client
-   :members:
-
-.. automodule:: sprockets.clients.http.mixins
+.. automodule:: sprockets.clients.http
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ html_theme_options = {
     'description': 'HTTP API client',
     'github_banner': True,
     'travis_button': True,
+    'codecov_button': True,
 }
 
 intersphinx_mapping = {

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,0 +1,12 @@
+.. :changelog:
+
+Release History
+===============
+
+`Next Release`_
+---------------
+- Add :class:`sprockets.clients.http.HTTPClient`
+- Add :class:`sprockets.clients.http.ClientMixin`
+- Add :class:`sprockets.clients.http.HTTPError`
+
+.. _Next Release: https://github.com/sprockets/sprockets.clients.http/compare/0.0.0...master

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 .. include:: ../README.rst
 
 .. toctree::
-   :maxdepth: 2
    :hidden:
 
    api
    examples
+   history

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,4 +4,5 @@
    :maxdepth: 2
    :hidden:
 
+   api
    examples

--- a/examples/rejected.py
+++ b/examples/rejected.py
@@ -16,7 +16,7 @@ class Consumer(http.ClientMixin, consumer.Consumer):
     @gen.coroutine
     def process(self):
         yield self.make_http_request(
-            'GET', 'http://httpbin.org', 'status', self.body,
+            'GET', 'http', 'httpbin.org', 'status', self.body,
             headers={'Accept': 'application/json'},
             on_error=self.translate_http_error)
 

--- a/examples/rejected.py
+++ b/examples/rejected.py
@@ -16,7 +16,7 @@ class Consumer(http.ClientMixin, consumer.Consumer):
     @gen.coroutine
     def process(self):
         yield self.make_http_request(
-            'http://httpbin.org', 'status', self.body,
+            'GET', 'http://httpbin.org', 'status', self.body,
             headers={'Accept': 'application/json'},
             on_error=self.translate_http_error)
 

--- a/examples/request_handler.py
+++ b/examples/request_handler.py
@@ -5,10 +5,14 @@ from tornado import gen, web
 class HttpBinHandler(http.ClientMixin, web.RequestHandler):
     """Sends requests to httpbin.org."""
 
+    def initialize(self):
+        super(HttpBinHandler, self).initialize()
+        self.base_url = self.settings.get('base_url', 'http://httpbin.org')
+
     @gen.coroutine
     def get(self, status_code):
         response = yield self.make_http_request(
-            'GET', 'http://httpbin.org', 'status', status_code,
+            'GET', self.base_url, 'status', status_code,
             on_error=self.handle_api_error)
 
         if not self._finished:
@@ -23,7 +27,7 @@ class HttpBinHandler(http.ClientMixin, web.RequestHandler):
     @gen.coroutine
     def post(self):
         response = yield self.make_http_request(
-            'POST', 'http://httpbin.org/post',
+            'POST', self.base_url, 'post',
             body=self.request.body, headers=self.request.headers)
 
         if not self._finished:

--- a/examples/request_handler.py
+++ b/examples/request_handler.py
@@ -7,13 +7,15 @@ class HttpBinHandler(http.ClientMixin, web.RequestHandler):
 
     def initialize(self):
         super(HttpBinHandler, self).initialize()
-        self.base_url = self.settings.get('base_url', 'http://httpbin.org')
+        self.scheme = self.settings.get('scheme', 'http')
+        self.server = self.settings.get('server', 'httpbin.org')
+        self.port = self.settings.get('port', None)
 
     @gen.coroutine
     def get(self, status_code):
         response = yield self.make_http_request(
-            'GET', self.base_url, 'status', status_code,
-            on_error=self.handle_api_error)
+            'GET', self.scheme, self.server, 'status', status_code,
+            port=self.port, on_error=self.handle_api_error)
 
         if not self._finished:
             self.set_status(200)
@@ -27,7 +29,7 @@ class HttpBinHandler(http.ClientMixin, web.RequestHandler):
     @gen.coroutine
     def post(self):
         response = yield self.make_http_request(
-            'POST', self.base_url, 'post',
+            'POST', self.scheme, self.server, 'post', port=self.port,
             body=self.request.body, headers=self.request.headers)
 
         if not self._finished:

--- a/examples/request_handler.py
+++ b/examples/request_handler.py
@@ -8,7 +8,7 @@ class HttpBinHandler(http.ClientMixin, web.RequestHandler):
     @gen.coroutine
     def get(self, status_code):
         response = yield self.make_http_request(
-            'http://httpbin.org', 'status', status_code,
+            'GET', 'http://httpbin.org', 'status', status_code,
             on_error=self.handle_api_error)
 
         if not self._finished:
@@ -23,7 +23,7 @@ class HttpBinHandler(http.ClientMixin, web.RequestHandler):
     @gen.coroutine
     def post(self):
         response = yield self.make_http_request(
-            'http://httpbin.org/post', method='POST',
+            'POST', 'http://httpbin.org/post',
             body=self.request.body, headers=self.request.headers)
 
         if not self._finished:

--- a/requires/testing.txt
+++ b/requires/testing.txt
@@ -1,1 +1,2 @@
 nose>=1.3.7,<2
+sprockets.http>=1,<2

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['examples']),
     namespace_packages=['sprockets', 'sprockets.clients'],
     install_requires=read_requirements('installation.txt'),
     tests_require=read_requirements('testing.txt'),

--- a/sprockets/clients/http/__init__.py
+++ b/sprockets/clients/http/__init__.py
@@ -1,2 +1,10 @@
+try:
+    from sprockets.clients.http.mixins import ClientMixin
+
+except ImportError as error:
+    def ClientMixin(*args, **kwargs):
+        raise error
+
 version_info = (0, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info)
+__all__ = ['version', '__version__', 'ClientMixin']

--- a/sprockets/clients/http/__init__.py
+++ b/sprockets/clients/http/__init__.py
@@ -1,10 +1,18 @@
 try:
+    from sprockets.clients.http.client import HTTPClient, HTTPError
     from sprockets.clients.http.mixins import ClientMixin
 
 except ImportError as error:
     def ClientMixin(*args, **kwargs):
         raise error
 
+    def HTTPClient(*args, **kwargs):
+        raise error
+
+    def HTTPError(*args, **kwargs):
+        raise error
+
 version_info = (0, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info)
-__all__ = ['version', '__version__', 'ClientMixin']
+__all__ = ['version_info', '__version__',
+           'ClientMixin', 'HTTPClient', 'HTTPError']

--- a/sprockets/clients/http/client.py
+++ b/sprockets/clients/http/client.py
@@ -1,9 +1,62 @@
 import logging
 
-from tornado import gen, httpclient
+from tornado import gen, httpclient, httputil
 
 
 log = logging.getLogger(__name__)
+
+
+class HTTPError(httpclient.HTTPError):
+    """
+    Extended Tornado HTTP Client Error.
+
+    The standard :class:`tornado.httpclient.HTTPError` is a little
+    difficult to use correctly and safely.  This sub-class makes
+    HTTP failures easier to use programatically.
+
+    .. rubric: Attributes
+
+    .. py:attribute:: request
+
+       :class:`tornado.httpclient.HTTPRequest` that failed
+
+    .. py:attribute:: code
+
+       Integer status code. This is usually a HTTP status code but
+       may be one of Tornado's internal status codes (e.g, 599 for a
+       timeout).
+
+    .. py:attribute:: reason
+
+       HTTP reason or the string ``Unknown``.
+
+    .. py:attribute:: response
+
+       :class:`tornado.httpclient.HTTPResponse` or :data:`None`
+
+    """
+
+    def __init__(self, request, code, reason=None, response=None):
+        self.reason = reason or httputil.responses.get(code, 'Unknown')
+        super(HTTPError, self).__init__(code, message=reason,
+                                        response=response)
+        self.request = request
+
+    @classmethod
+    def from_tornado_error(cls, http_request, http_error):
+        """
+        Convert a Tornado client error.
+
+        :param tornado.httpclient.HTTPRequest http_request:
+            the request that caused the error
+        :param tornado.httpclient.HTTPError http_error:
+            the underlying Tornado failure
+        :return: a compatible instance of :class:`.HTTPError`
+
+        """
+        response = http_error.response
+        return HTTPError(http_request, http_error.code, response=response,
+                         reason=None if response is None else response.reason)
 
 
 class HTTPClient(object):
@@ -21,20 +74,26 @@ class HTTPClient(object):
     """
 
     def __init__(self, *args, **kwargs):
-        super(HTTPClient, self).__init__(*args, **kwargs)
+        super(HTTPClient, self).__init__()
         self.client = httpclient.AsyncHTTPClient(*args, **kwargs)
         self.logger = log.getChild(self.__class__.__name__)
 
     @gen.coroutine
-    def send_request(self, request):
+    def send_request(self, method, server, *path, **kwargs):
         """
         Send a HTTP request.
 
         :param tornado.httpclient.HTTPRequest request: the request to send
         :returns: :class:`tornado.httpclient.HTTPResponse` instance
-        :raises: :class:`tornado.httpclient.HTTPError`
+        :raises: :class:`.HTTPError`
 
         """
+        target = '{}/{}'.format(server, '/'.join(str(s) for s in path))
+        request = httpclient.HTTPRequest(target, method=method, **kwargs)
         self.logger.debug('sending %s %s', request.method, request.url)
-        response = yield self.client.fetch(request)
-        raise gen.Return(response)
+        try:
+            response = yield self.client.fetch(request)
+            raise gen.Return(response)
+
+        except httpclient.HTTPError as error:
+            raise HTTPError.from_tornado_error(request, error)

--- a/sprockets/clients/http/client.py
+++ b/sprockets/clients/http/client.py
@@ -92,6 +92,11 @@ class HTTPClient(object):
     underlying ``AsyncHTTPClient`` instance using the :attr:`.client`
     attribute if need be.
 
+    .. attribute:: headers
+
+       :class:`tornado.httputil.HTTPHeaders` instance that is sent with
+       each HTTP Request.
+
     """
 
     def __init__(self, *args, **kwargs):
@@ -99,6 +104,7 @@ class HTTPClient(object):
         self._client_args = args
         self._client_kwargs = kwargs
         self._client = None
+        self.headers = httputil.HTTPHeaders()
         self.logger = log.getChild(self.__class__.__name__)
 
     @property
@@ -135,6 +141,13 @@ class HTTPClient(object):
         target = '{}://{}/{}'.format(scheme, netloc,
                                      '/'.join(parse.quote(str(s), safe='')
                                               for s in path))
+        if 'headers' in kwargs:
+            headers = self.headers.copy()
+            headers.update(kwargs.pop('headers'))
+            kwargs['headers'] = headers
+        else:
+            kwargs['headers'] = self.headers
+
         request = httpclient.HTTPRequest(target, method=method, **kwargs)
         self.logger.debug('sending %s %s', request.method, request.url)
         try:

--- a/sprockets/clients/http/client.py
+++ b/sprockets/clients/http/client.py
@@ -88,14 +88,26 @@ class HTTPClient(object):
         initializer
 
     This class serves as a more intelligent version of
-    :class:`~tornado.httpclient.AsyncHTTPClient`.
+    :class:`~tornado.httpclient.AsyncHTTPClient`.  You can access the
+    underlying ``AsyncHTTPClient`` instance using the :attr:`.client`
+    attribute if need be.
 
     """
 
     def __init__(self, *args, **kwargs):
         super(HTTPClient, self).__init__()
-        self.client = httpclient.AsyncHTTPClient(*args, **kwargs)
+        self._client_args = args
+        self._client_kwargs = kwargs
+        self._client = None
         self.logger = log.getChild(self.__class__.__name__)
+
+    @property
+    def client(self):
+        """Underlying :class:`tornado.httpclient.AsyncHTTPClient` instance"""
+        if self._client is None:
+            self._client = httpclient.AsyncHTTPClient(*self._client_args,
+                                                      **self._client_kwargs)
+        return self._client
 
     @gen.coroutine
     def send_request(self, method, scheme, host, *path, **kwargs):

--- a/sprockets/clients/http/client.py
+++ b/sprockets/clients/http/client.py
@@ -1,0 +1,40 @@
+import logging
+
+from tornado import gen, httpclient
+
+
+log = logging.getLogger(__name__)
+
+
+class HTTPClient(object):
+    """
+    HTTP client connector.
+
+    :param args: passed to :class:`~tornado.httpclient.AsyncHTTPClient`
+        initializer
+    :param kwargs: passed to :class:`~tornado.httpclient.AsyncHTTPClient`
+        initializer
+
+    This class serves as a more intelligent version of
+    :class:`~tornado.httpclient.AsyncHTTPClient`.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(HTTPClient, self).__init__(*args, **kwargs)
+        self.client = httpclient.AsyncHTTPClient(*args, **kwargs)
+        self.logger = log.getChild(self.__class__.__name__)
+
+    @gen.coroutine
+    def send_request(self, request):
+        """
+        Send a HTTP request.
+
+        :param tornado.httpclient.HTTPRequest request: the request to send
+        :returns: :class:`tornado.httpclient.HTTPResponse` instance
+        :raises: :class:`tornado.httpclient.HTTPError`
+
+        """
+        self.logger.debug('sending %s %s', request.method, request.url)
+        response = yield self.client.fetch(request)
+        raise gen.Return(response)

--- a/sprockets/clients/http/client.py
+++ b/sprockets/clients/http/client.py
@@ -1,6 +1,6 @@
 import logging
 
-from tornado import gen, httpclient, httputil
+from tornado import gen, httpclient, httputil, web
 
 
 log = logging.getLogger(__name__)
@@ -57,6 +57,20 @@ class HTTPError(httpclient.HTTPError):
         response = http_error.response
         return HTTPError(http_request, http_error.code, response=response,
                          reason=None if response is None else response.reason)
+
+    def to_server_error(self):
+        """
+        Convert a client error into a :class:`tornado.web.HTTPError`
+
+        :return: a compatible :class:`tornado.web.HTTPError` instance
+
+        """
+        if self.code == 599:  # tornado custom response code
+            exc = web.HTTPError(503, 'API Timeout')
+        else:
+            exc = web.HTTPError(self.code)
+            exc.reason = self.reason
+        return exc
 
 
 class HTTPClient(object):

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -69,5 +69,6 @@ class ClientMixin(object):
                 log = self.logger.error
             else:
                 log = self.logger.warn
-            log('%s %s resulted in %r', request.method, request.url, error)
+            log('%s %s resulted in %s %s', request.method, request.url,
+                error.code, error.message)
             on_error(self, request, error)

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -1,6 +1,6 @@
 import logging
 
-from tornado import gen, httpclient, web
+from tornado import gen, httpclient, httputil, web
 
 
 def default_error_handler(handler_, request_, error):
@@ -20,9 +20,14 @@ def default_error_handler(handler_, request_, error):
     that the server framework expects.
 
     """
-    exc = web.HTTPError(error.code)
-    if getattr(error, 'response'):
-        exc.reason = error.response.reason
+    if error.code == 599:  # tornado custom response code
+        exc = web.HTTPError(503, 'API Timeout')
+    else:
+        exc = web.HTTPError(error.code)
+        if getattr(error, 'response'):
+            exc.reason = error.response.reason
+        if exc.reason is None:
+            exc.reason = httputil.responses.get(error.code, 'Unknown Error')
     raise exc
 
 

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -1,5 +1,6 @@
 import logging
 
+from sprockets.clients.http import client
 from tornado import gen, httpclient, httputil, web
 
 
@@ -36,7 +37,7 @@ class ClientMixin(object):
 
     def initialize(self):
         super(ClientMixin, self).initialize()
-        self.__client = httpclient.AsyncHTTPClient()
+        self.__client = client.HTTPClient()
         if not hasattr(self, 'logger'):
             self.logger = logging.getLogger(self.__class__.__name__)
 
@@ -63,8 +64,7 @@ class ClientMixin(object):
         request = httpclient.HTTPRequest(url, method=method, **kwargs)
 
         try:
-            self.logger.debug('sending %s %s', request.method, request.url)
-            response = yield self.__client.fetch(request)
+            response = yield self.__client.send_request(request)
             raise gen.Return(response)
 
         except httpclient.HTTPError as error:

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -24,11 +24,19 @@ def default_error_handler(handler_, request_, error):
 
 
 class ClientMixin(object):
-    """Mix this in to add the ``make_http_request`` method."""
+    """
+    Mix this in to add the ``make_http_request`` method.
+
+    .. attribute:: http_client
+
+       The :class:`~sprockets.clients.http.client.HTTPClient` instance
+       that :meth:`.make_http_request` uses.
+
+    """
 
     def initialize(self):
         super(ClientMixin, self).initialize()
-        self.__client = client.HTTPClient()
+        self.http_client = client.HTTPClient()
         if not hasattr(self, 'logger'):
             self.logger = logging.getLogger(self.__class__.__name__)
 
@@ -59,9 +67,8 @@ class ClientMixin(object):
         port = kwargs.pop('port', None)
         on_error = kwargs.pop('on_error', None) or default_error_handler
         try:
-            response = yield self.__client.send_request(method, scheme, host,
-                                                        *path, port=port,
-                                                        **kwargs)
+            response = yield self.http_client.send_request(
+                method, scheme, host, *path, port=port, **kwargs)
             raise gen.Return(response)
 
         except client.HTTPError as error:

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -32,7 +32,8 @@ class ClientMixin(object):
     def initialize(self):
         super(ClientMixin, self).initialize()
         self.__client = httpclient.AsyncHTTPClient()
-        self.logger = logging.getLogger(self.__class__.__name__)
+        if not hasattr(self, 'logger'):
+            self.logger = logging.getLogger(self.__class__.__name__)
 
     @gen.coroutine
     def make_http_request(self, server, *path, **kwargs):

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -1,7 +1,7 @@
 import logging
 
 from sprockets.clients.http import client
-from tornado import gen, httpclient, httputil, web
+from tornado import gen
 
 
 def default_error_handler(handler_, request_, error):
@@ -12,24 +12,15 @@ def default_error_handler(handler_, request_, error):
         the request hander that made the request
     :param tornado.httpclient.HTTPRequest request_:
         the HTTP request that failed
-    :param tornado.httpclient.HTTPError error:
+    :param sprockets.clients.http.client.HTTPError error:
         the error that was returned
 
     This is the default error handler for :class:`.ClientMixin`.
-    It simply translates the :class:`~tornado.httpclient.HTTPError`
-    that the client generates into a :class:`tornado.web.HTTPError`
+    It simply translates `error` into a :class:`tornado.web.HTTPError`
     that the server framework expects.
 
     """
-    if error.code == 599:  # tornado custom response code
-        exc = web.HTTPError(503, 'API Timeout')
-    else:
-        exc = web.HTTPError(error.code)
-        if getattr(error, 'response'):
-            exc.reason = error.response.reason
-        if exc.reason is None:
-            exc.reason = httputil.responses.get(error.code, 'Unknown Error')
-    raise exc
+    raise error.to_server_error()
 
 
 class ClientMixin(object):

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -72,3 +72,11 @@ class ClientMixin(object):
             log('%s %s resulted in %s %s', request.method, request.url,
                 error.code, error.message)
             on_error(self, request, error)
+
+    def set_status(self, status_code, reason=None):
+        # Overridden to remove the raising of ValueError when
+        # reason is None and status is a custom code.
+        try:
+            super(ClientMixin, self).set_status(status_code, reason)
+        except ValueError:
+            super(ClientMixin, self).set_status(status_code, 'Unknown Reason')

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -41,14 +41,13 @@ class ClientMixin(object):
             self.logger = logging.getLogger(self.__class__.__name__)
 
     @gen.coroutine
-    def make_http_request(self, server, *path, **kwargs):
+    def make_http_request(self, method, server, *path, **kwargs):
         """
         Make a HTTP request and process the response.
 
+        :param str method: HTTP method to invoke
         :param str server: the host to send the request to
         :param path: resource path to request
-        :keyword str method: HTTP method to invoke.  If unspecifed,
-            the default is ``GET``.
         :keyword on_error: function to call if an error occurs.  If
             unspecified, :func:`.default_error_handler` is called.
         :param kwargs: additional keyword arguments are passed to the
@@ -60,9 +59,8 @@ class ClientMixin(object):
 
         """
         on_error = kwargs.pop('on_error', default_error_handler)
-        kwargs.setdefault('method', 'GET')
         url = '{}/{}'.format(server, '/'.join(path)) if path else server
-        request = httpclient.HTTPRequest(url, **kwargs)
+        request = httpclient.HTTPRequest(url, method=method, **kwargs)
 
         try:
             self.logger.debug('sending %s %s', request.method, request.url)

--- a/sprockets/clients/http/mixins.py
+++ b/sprockets/clients/http/mixins.py
@@ -1,0 +1,72 @@
+import logging
+
+from tornado import gen, httpclient, web
+
+
+def default_error_handler(handler_, request_, error):
+    """
+    Translates a HTTP client error to a server error.
+
+    :param tornado.web.RequestHandler handler_:
+        the request hander that made the request
+    :param tornado.httpclient.HTTPRequest request_:
+        the HTTP request that failed
+    :param tornado.httpclient.HTTPError error:
+        the error that was returned
+
+    This is the default error handler for :class:`.ClientMixin`.
+    It simply translates the :class:`~tornado.httpclient.HTTPError`
+    that the client generates into a :class:`tornado.web.HTTPError`
+    that the server framework expects.
+
+    """
+    exc = web.HTTPError(error.code)
+    if getattr(error, 'response'):
+        exc.reason = error.response.reason
+    raise exc
+
+
+class ClientMixin(object):
+    """Mix this in to add the ``make_http_request`` method."""
+
+    def initialize(self):
+        super(ClientMixin, self).initialize()
+        self.__client = httpclient.AsyncHTTPClient()
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    @gen.coroutine
+    def make_http_request(self, server, *path, **kwargs):
+        """
+        Make a HTTP request and process the response.
+
+        :param str server: the host to send the request to
+        :param path: resource path to request
+        :keyword str method: HTTP method to invoke.  If unspecifed,
+            the default is ``GET``.
+        :keyword on_error: function to call if an error occurs.  If
+            unspecified, :func:`.default_error_handler` is called.
+        :param kwargs: additional keyword arguments are passed to the
+            :class:`tornado.httpclient.HTTPRequest` initializer.
+
+        The ``on_error`` function is called with three parameters: the
+        handler (i.e., ``self``), the :class:`~tornado.httpclient.HTTPRequest`
+        that failed, and the :class:`~tornado.httpclient.HTTPError`.
+
+        """
+        on_error = kwargs.pop('on_error', default_error_handler)
+        kwargs.setdefault('method', 'GET')
+        url = '{}/{}'.format(server, '/'.join(path)) if path else server
+        request = httpclient.HTTPRequest(url, **kwargs)
+
+        try:
+            self.logger.debug('sending %s %s', request.method, request.url)
+            response = yield self.__client.fetch(request)
+            raise gen.Return(response)
+
+        except httpclient.HTTPError as error:
+            if error.code < 500:
+                log = self.logger.error
+            else:
+                log = self.logger.warn
+            log('%s %s resulted in %r', request.method, request.url, error)
+            on_error(self, request, error)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import os
+
+HTTPBIN_SERVER = os.environ.get('HTTPBIN_HOST', 'httpbin.org')
+HTTPBIN_PORT = os.environ.get('HTTPBIN_PORT', None)
+if HTTPBIN_PORT:
+    HTTPBIN_URL = 'http://{}:{}'.format(HTTPBIN_SERVER, HTTPBIN_PORT)
+else:
+    HTTPBIN_URL = 'http://{}'.format(HTTPBIN_SERVER)

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -1,18 +1,11 @@
 import json
-import os
 
 from tornado import httpserver, testing, web
 import tornado.httpclient
 
 from sprockets.clients.http import client
 
-
-HTTPBIN_SERVER = os.environ.get('HTTPBIN_HOST', 'httpbin.org')
-HTTPBIN_PORT = os.environ.get('HTTPBIN_PORT', None)
-if HTTPBIN_PORT:
-    HTTPBIN_URL = 'http://{}:{}'.format(HTTPBIN_SERVER, HTTPBIN_PORT)
-else:
-    HTTPBIN_URL = 'http://{}'.format(HTTPBIN_SERVER)
+from tests import HTTPBIN_PORT, HTTPBIN_SERVER, HTTPBIN_URL
 
 
 class EchoHandler(web.RequestHandler):

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -70,3 +70,6 @@ class HttpClientTests(testing.AsyncTestCase):
         body = json.loads(response.body.decode('utf-8'))
         self.assertEqual(body['kwargs'], {'one': 'with spaces ',
                                           'two': 'and/with/slashes'})
+
+    def test_that_client_is_cached(self):
+        self.assertIs(self.client.client, self.client.client)

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -1,0 +1,42 @@
+import os
+
+from tornado import testing
+import tornado.httpclient
+
+from sprockets.clients.http import client
+
+
+HTTPBIN_BASE_URL = 'http://{}:{}'.format(
+    os.environ.get('HTTPBIN_HOST', 'httpbin.org'),
+    os.environ.get('HTTPBIN_PORT', '80'))
+
+
+class HttpClientTests(testing.AsyncTestCase):
+
+    def setUp(self):
+        super(HttpClientTests, self).setUp()
+        self.client = client.HTTPClient()
+
+    @testing.gen_test
+    def test_that_builds_simple_url(self):
+        response = yield self.client.send_request(
+            'GET', HTTPBIN_BASE_URL, 'get')
+        self.assertEqual(response.code, 200)
+
+    @testing.gen_test
+    def test_that_customized_httperror_is_raised(self):
+        try:
+            yield self.client.send_request('GET', HTTPBIN_BASE_URL,
+                                           'status', 593)
+        except tornado.httpclient.HTTPError as error:
+            self.assertIsInstance(error, client.HTTPError)
+            self.assertIsInstance(error.request,
+                                  tornado.httpclient.HTTPRequest)
+            self.assertEqual(error.request.method, 'GET')
+            self.assertEqual(error.request.url,
+                             '{}/status/593'.format(HTTPBIN_BASE_URL))
+            self.assertEqual(error.code, 593)
+            self.assertEqual(error.reason, 'UNKNOWN')
+
+        else:
+            self.fail('sprockets.clients.http.client.HTTPError was not raised')

--- a/tests/client_tests.py
+++ b/tests/client_tests.py
@@ -1,14 +1,28 @@
+import json
 import os
 
-from tornado import testing
+from tornado import httpserver, testing, web
 import tornado.httpclient
 
 from sprockets.clients.http import client
 
 
-HTTPBIN_BASE_URL = 'http://{}:{}'.format(
-    os.environ.get('HTTPBIN_HOST', 'httpbin.org'),
-    os.environ.get('HTTPBIN_PORT', '80'))
+HTTPBIN_SERVER = os.environ.get('HTTPBIN_HOST', 'httpbin.org')
+HTTPBIN_PORT = os.environ.get('HTTPBIN_PORT', None)
+if HTTPBIN_PORT:
+    HTTPBIN_URL = 'http://{}:{}'.format(HTTPBIN_SERVER, HTTPBIN_PORT)
+else:
+    HTTPBIN_URL = 'http://{}'.format(HTTPBIN_SERVER)
+
+
+class EchoHandler(web.RequestHandler):
+
+    def get(self, *path, **kwargs):
+        self.write(json.dumps({
+            'path': path,
+            'kwargs': kwargs,
+        }).encode('utf-8'))
+        self.set_status(200)
 
 
 class HttpClientTests(testing.AsyncTestCase):
@@ -17,26 +31,49 @@ class HttpClientTests(testing.AsyncTestCase):
         super(HttpClientTests, self).setUp()
         self.client = client.HTTPClient()
 
+    def start_application(self, app):
+        server = httpserver.HTTPServer(request_callback=app,
+                                       io_loop=self.io_loop)
+        server.listen(0, address='127.0.0.1')
+        socks = list(server._sockets.keys())
+        return server._sockets[socks[0]].getsockname()
+
     @testing.gen_test
     def test_that_builds_simple_url(self):
         response = yield self.client.send_request(
-            'GET', HTTPBIN_BASE_URL, 'get')
+            'GET', 'http', HTTPBIN_SERVER, 'get', port=HTTPBIN_PORT)
         self.assertEqual(response.code, 200)
 
     @testing.gen_test
     def test_that_customized_httperror_is_raised(self):
         try:
-            yield self.client.send_request('GET', HTTPBIN_BASE_URL,
-                                           'status', 593)
+            yield self.client.send_request('GET', 'http', HTTPBIN_SERVER,
+                                           'status', 593, port=HTTPBIN_PORT)
         except tornado.httpclient.HTTPError as error:
             self.assertIsInstance(error, client.HTTPError)
             self.assertIsInstance(error.request,
                                   tornado.httpclient.HTTPRequest)
             self.assertEqual(error.request.method, 'GET')
             self.assertEqual(error.request.url,
-                             '{}/status/593'.format(HTTPBIN_BASE_URL))
+                             '{}/status/593'.format(HTTPBIN_URL))
             self.assertEqual(error.code, 593)
             self.assertEqual(error.reason, 'UNKNOWN')
 
         else:
             self.fail('sprockets.clients.http.client.HTTPError was not raised')
+
+    @testing.gen_test
+    def test_that_path_elements_are_url_encoded(self):
+        app = web.Application([
+            web.url('/(?P<one>.*)/(?P<two>.*)', EchoHandler),
+        ])
+        server_ip, server_port = self.start_application(app)
+
+        response = yield self.client.send_request(
+            'GET', 'http', server_ip, 'with spaces ', 'and/with/slashes',
+            port=server_port,
+        )
+        self.assertEqual(response.code, 200)
+        body = json.loads(response.body.decode('utf-8'))
+        self.assertEqual(body['kwargs'], {'one': 'with spaces ',
+                                          'two': 'and/with/slashes'})

--- a/tests/mixin_tests.py
+++ b/tests/mixin_tests.py
@@ -106,3 +106,7 @@ class MixinTests(testing.AsyncHTTPTestCase):
 
         body = json.loads(response.body.decode('utf-8'))
         self.assertEqual(body['json']['uid'], uid)
+
+    def test_that_mixin_supports_custom_response_codes(self):
+        response = self.fetch('/601')
+        self.assertEqual(response.code, 601)

--- a/tests/mixin_tests.py
+++ b/tests/mixin_tests.py
@@ -1,0 +1,81 @@
+import json
+import logging
+import uuid
+
+from tornado import testing
+
+from examples import request_handler
+
+
+class RecordingHandler(logging.Handler):
+    """Log handler that records what was logged."""
+    def __init__(self, *args, **kwargs):
+        logging.Handler.__init__(self, *args, **kwargs)
+        self.records = []
+        self.lines = []
+
+    def emit(self, record):
+        self.records.append(record)
+        self.lines.append(self.format(record))
+
+
+class LoggingTests(testing.AsyncHTTPTestCase):
+
+    def setUp(self):
+        super(LoggingTests, self).setUp()
+        self.log_handler = RecordingHandler(level=logging.DEBUG)
+        logger = logging.getLogger('HttpBinHandler')
+        logger.addHandler(self.log_handler)
+
+    def tearDown(self):
+        super(LoggingTests, self).tearDown()
+        logger = logging.getLogger('HttpBinHandler')
+        logger.removeHandler(self.log_handler)
+
+    def get_app(self):
+        return request_handler.make_application()
+
+    def find_log_line_containing(self, value):
+        for index, line in enumerate(self.log_handler.lines):
+            if value in line:
+                return index
+        self.fail('Did not find log line containing "{}"'.format(value))
+
+    def test_that_requests_are_logged_at_debug_level(self):
+        self.fetch('/200')
+        log_index = self.find_log_line_containing('sending GET ')
+        self.assertEqual(self.log_handler.records[log_index].levelno,
+                         logging.DEBUG)
+        self.assertIn('GET http://httpbin.org/status/200',
+                      self.log_handler.lines[log_index])
+
+    def test_that_client_errors_are_logged_at_error_level(self):
+        self.fetch('/400')
+        log_index = self.find_log_line_containing(
+            'GET http://httpbin.org/status/400 resulted in')
+        self.assertEqual(self.log_handler.records[log_index].levelno,
+                         logging.ERROR)
+
+    def test_that_server_errors_are_logged_at_warning_level(self):
+        self.fetch('/500')
+        log_index = self.find_log_line_containing(
+            'GET http://httpbin.org/status/500 resulted in')
+        self.assertEqual(self.log_handler.records[log_index].levelno,
+                         logging.WARN)
+
+
+class MixinTests(testing.AsyncHTTPTestCase):
+
+    def get_app(self):
+        app = request_handler.make_application()
+        return app
+
+    def test_that_response_is_returned(self):
+        uid = str(uuid.uuid4())
+        response = self.fetch('/post', method='POST',
+                              body=json.dumps({'uid': uid}),
+                              headers={'Content-Type': 'application/json'})
+        self.assertEqual(response.code, 200)
+
+        body = json.loads(response.body.decode('utf-8'))
+        self.assertEqual(body['json']['uid'], uid)

--- a/tests/mixin_tests.py
+++ b/tests/mixin_tests.py
@@ -34,7 +34,7 @@ class TestingHandler(http.ClientMixin, web.RequestHandler):
         conn_timeout = self.get_query_argument('connect_timeout', None)
         if conn_timeout is not None:
             kwargs['connect_timeout'] = float(conn_timeout)
-        response = yield self.make_http_request(server, 'status',
+        response = yield self.make_http_request('GET', server, 'status',
                                                 status_code, **kwargs)
         self.logger.info('got it')
         self.set_status(response.code)

--- a/tests/mixin_tests.py
+++ b/tests/mixin_tests.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import uuid
 
 from tornado import gen, testing, web
@@ -8,13 +7,7 @@ from tornado import gen, testing, web
 from examples import request_handler
 from sprockets.clients import http
 
-
-HTTPBIN_SERVER = os.environ.get('HTTPBIN_HOST', 'httpbin.org')
-HTTPBIN_PORT = os.environ.get('HTTPBIN_PORT', None)
-if HTTPBIN_PORT:
-    HTTPBIN_URL = 'http://{}:{}'.format(HTTPBIN_SERVER, HTTPBIN_PORT)
-else:
-    HTTPBIN_URL = 'http://{}'.format(HTTPBIN_SERVER)
+from tests import HTTPBIN_PORT, HTTPBIN_SERVER, HTTPBIN_URL
 
 
 class RecordingHandler(logging.Handler):

--- a/tests/mixin_tests.py
+++ b/tests/mixin_tests.py
@@ -41,17 +41,20 @@ class TestingHandler(http.ClientMixin, web.RequestHandler):
 
 
 class LoggingTests(testing.AsyncHTTPTestCase):
+    LOGGERS = ['HttpBinHandler',
+               'sprockets.clients.http.client.HTTPClient',
+               'testing']
 
     def setUp(self):
         super(LoggingTests, self).setUp()
         self.log_handler = RecordingHandler(level=logging.DEBUG)
-        logging.getLogger('HttpBinHandler').addHandler(self.log_handler)
-        logging.getLogger('testing').addHandler(self.log_handler)
+        for logger in self.LOGGERS:
+            logging.getLogger(logger).addHandler(self.log_handler)
 
     def tearDown(self):
         super(LoggingTests, self).tearDown()
-        logging.getLogger('HttpBinHandler').removeHandler(self.log_handler)
-        logging.getLogger('testing').removeHandler(self.log_handler)
+        for logger in self.LOGGERS:
+            logging.getLogger(logger).removeHandler(self.log_handler)
 
     def get_app(self):
         app = request_handler.make_application()


### PR DESCRIPTION
This PR implements a very simple HTTP client wrapper with a error handling callback.  The `ClientMixin` class adds a client instance as the `http_client` attribute and exposes a single new method for making HTTP requests -- `make_http_request`.  Calling `make_http_request` looks something like:

``` python
response = yield self.make_http_request('GET', 'http', 'httpbin.org', 'status', 400)
```

Note that the client takes care of the many of the URL-related details for you though it looks like I forgot to add automatic query encoding _(easy enough to add that shortly)_.  The response is a `tornado.httpclient.HTTPResponse` object.  Failures result in `tornado.web.HTTPError` being raised.  

You can specify your own error handling callback by including a `on_error` keyword parameter to `make_http_request`.  It will be called with the request handler instance, the request that was made, and the `sprockets.clients.http.HTTPError` that was raised.  The default looks something like:

``` python
def on_error(handler, request, error):
    raise error.to_server_error()
```

The `HTTPClient` class will be useful from things other than `tornado.web.RequestHandler`, _"yes", `rejected.Consumer` sub-classes I'm looking at you_.  Though it is little more than a wrapper around `tornado.httpclient.HTTPClient` currently, I want to add smart content handling in the client class in the near future.  For the time-being, it simply provides some insulation around tornado's `httpclient.HTTPError` and `web.HTTPError` dichotomy by introducing another type named `HTTPError` _(why stop at two right?)_ that knows how to convert itself to a `web.HTTPError` which is what we usually want.
