### PR TITLE
Add ClientMixin.on_request_error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,7 @@ not block the active IO loop.
 
        @gen.coroutine
        def get(self):
-           response = yield self.make_http_request(
-               'GET', some_server_url, on_error=self.handle_api_error)
+           response = yield self.make_http_request('GET', some_server_url)
            if self._finished:
                yield gen.Return()
 
@@ -26,7 +25,7 @@ not block the active IO loop.
            # ...
            self.finish()
 
-       def handle_api_error(self, request, error):
+       def on_http_request_error(self, request, error):
            self.send_error(error.code)
 
 That's it.  What you do not see is asynchronous client usage and logging

--- a/examples/request_handler.py
+++ b/examples/request_handler.py
@@ -15,7 +15,7 @@ class HttpBinHandler(http.ClientMixin, web.RequestHandler):
     def get(self, status_code):
         response = yield self.make_http_request(
             'GET', self.scheme, self.server, 'status', status_code,
-            port=self.port, on_error=self.handle_api_error)
+            port=self.port)
 
         if not self._finished:
             self.set_status(200)
@@ -41,11 +41,10 @@ class HttpBinHandler(http.ClientMixin, web.RequestHandler):
                 self.write(response.body)
             self.finish()
 
-    def handle_api_error(self, _, request, error):
+    def on_http_request_error(self, request, error):
         """
         Call ``send_error`` based on a httpclient.HTTPError.
 
-        :param tornado.web.RequestHandler _: handler that made the request
         :param tornado.web.HTTPRequest request: the request that was made
         :param tornado.httpclient.HTTPError error: the failure
 

--- a/sprockets/clients/http/client.py
+++ b/sprockets/clients/http/client.py
@@ -115,6 +115,11 @@ class HTTPClient(object):
                                                       **self._client_kwargs)
         return self._client
 
+    @property
+    def io_loop(self):
+        """:class:`tornado.ioloop.IOLoop` instance used by the client."""
+        return self.client.io_loop
+
     def send_request(self, method, scheme, host, *path, **kwargs):
         """
         Send a HTTP request.
@@ -157,12 +162,12 @@ class HTTPClient(object):
             try:
                 future.set_result(f.result())
             except httpclient.HTTPError as error:
-                future.set_exception(HTTPError.from_tornado_error(request,
-                                                                  error))
+                future.set_exception(
+                    HTTPError.from_tornado_error(request, error))
             except Exception as exception:
                 future.set_exception(exception)
 
         coro = self.client.fetch(request)
-        self.client.io_loop.add_future(coro, handle_response)
+        self.io_loop.add_future(coro, handle_response)
 
         return future


### PR DESCRIPTION
This PR replaces the `default_error_handler` function with a method that is customizable.  It also reworks the handling of futures to use the canonical pattern:

``` python
def handle_future(f):
   exc = f.exception()
   if exc is not None:
      # process failure
   else:
      # process f.result()
```

I was simply fetching the result in a `try` block.  I haven't convinced myself that using a `try` around `f.result()` is completely reliable so I switched to the pattern that is documented.
